### PR TITLE
Add guild channel to db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ playground*
 holding*
 test*
 .DS_Store*
+/backup
+/audio

--- a/controller.py
+++ b/controller.py
@@ -229,7 +229,7 @@ async def vocalroll(ctx, *, text=None):
 
     try:
         # Lets play that mp3 file in the voice channel
-        vc.play(discord.FFmpegPCMAudio('text.mp3'), after=lambda e: print(f"Finished playing: {e}"))
+        vc.play(discord.FFmpegPCMAudio('audio/text.mp3'), after=lambda e: print(f"Finished playing: {e}"))
         #vc.play(discord.FFmpegPCMAudio('audio/god.mp3'), after=lambda e: print(f"Finished playing: {e}"))
 
         # Lets set the volume to 1

--- a/controller.py
+++ b/controller.py
@@ -92,7 +92,7 @@ async def r(ctx, *, arg=None):
 async def lastrolls(ctx, *, arg=None):
 
     if mathtools.RepresentsInt(arg): #is the argument an integer value
-        rolls = database.get_entry(number_of_entries=int(arg))
+        rolls = database.get_entries_as_string(number_of_entries=int(arg))
         description = "LAST ROLLS\n"
         for roll in rolls:
             print (roll)

--- a/controller.py
+++ b/controller.py
@@ -9,7 +9,7 @@ bot = commands.Bot(command_prefix=['.','!'], description="Call of Cthulhu Dicebo
 
 @bot.event
 async def on_ready():
-    print('We have logged in as {0.user}'.format(bot))
+    print('Logged in as {0.user}... we are alive!'.format(bot))
 
 @bot.command(pass_context=True)
 async def r(ctx, *, arg=None):
@@ -26,7 +26,12 @@ async def r(ctx, *, arg=None):
     # putting all results in the database.  It skips nothing, including failures and syntax errors!
     for roll in dice.getrolls():
         print("{} {} {} {} {} {} {} {} {} {}".format(ctx.guild, ctx.channel, ctx.author, ctx.author.display_name, arg, roll.get_equation(), roll.get_sumtotal(), roll.get_stat(), roll.get_success(), roll.get_comment()))
-        database.add_roll(str(ctx.author), ctx.author.display_name, arg, roll.get_equation(), roll.get_sumtotal(), roll.get_stat(), roll.get_success(), roll.get_comment())
+
+        # comment that keeps the roll of the db for testing purposes
+        if dice.getroll().get_comment() is not None:
+            if "^test" not in dice.getroll().get_comment():
+                print ("Roll added to Database!")
+                database.add_roll(str(ctx.author), ctx.author.display_name, arg, roll.get_equation(), roll.get_sumtotal(), roll.get_stat(), roll.get_success(), roll.get_comment())
 
     # FAIL: in this event, the sum of the rolls is NONE, which indicates there was a problem in the syntax or code.  Produces error.
     if dice.getroll().get_sumtotal() == None:

--- a/controller.py
+++ b/controller.py
@@ -29,11 +29,11 @@ async def r(ctx, *, arg=None):
     for roll in dice.getrolls():
         print("{} {} {} {} {} {} {} {} {} {}".format(ctx.guild, ctx.channel, ctx.author, ctx.author.display_name, arg, roll.get_equation(), roll.get_sumtotal(), roll.get_stat(), roll.get_success(), roll.get_comment()))
 
-        # comment that keeps the roll of the db for testing purposes
-        if dice.getroll().get_comment() is not None:
-            if "^test" not in dice.getroll().get_comment():
-                print ("Roll added to Database!")
-                database.add_roll(str(ctx.author), ctx.author.display_name, arg, roll.get_equation(), roll.get_sumtotal(), roll.get_stat(), roll.get_success(), roll.get_comment())
+        # if ^test is present in the comment, the roll will not be store in the db (for testing purposes)
+        if dice.getroll().get_comment() is not None and "^test" in dice.getroll().get_comment():
+            print ("Roll NOT added to Database!")
+        else:
+            database.add_roll(str(ctx.author), ctx.author.display_name, arg, roll.get_equation(), roll.get_sumtotal(), roll.get_stat(), roll.get_success(), roll.get_comment(), str(ctx.guild), str(ctx.channel))
 
     # FAIL: in this event, the sum of the rolls is NONE, which indicates there was a problem in the syntax or code.  Produces error.
     if dice.getroll().get_sumtotal() == None:

--- a/database.py
+++ b/database.py
@@ -16,7 +16,9 @@ def initialize_db():
             result int,
             stat int,
             success text,
-            comment text)''')
+            comment text,
+            guild text,
+            channel text)''')
 
     # Creates table if the tables don't exist.
     c.execute('''CREATE TABLE IF NOT EXISTS licorice
@@ -29,15 +31,14 @@ def initialize_db():
     conn.close()
 
 # adds the player roll to the database.  Repeated rolls are separate entries.
-def add_roll(user=None, nick=None, argument=None, equation=None, result=None, stat=None, success=None, comment=None):
+def add_roll(user=None, nick=None, argument=None, equation=None, result=None, stat=None, success=None, comment=None, guild=None, channel=None):
     conn = sqlite3.connect('dicebot.db')
     c = conn.cursor()
 
-    sql = "INSERT INTO rolls (messagetime, user, nick, argument, equation, result, stat, success, comment) VALUES (?,?,?,?,?,?,?,?,?)"
-    values = (time.time(), user, nick, argument, equation, result, stat, success, comment)
+    sql = "INSERT INTO rolls (messagetime, user, nick, argument, equation, result, stat, success, comment, guild, channel) VALUES (?,?,?,?,?,?,?,?,?,?,?)"
+    values = (time.time(), user, nick, argument, equation, result, stat, success, comment, guild, channel)
     c.execute(sql,values)
     conn.commit()
-    
     conn.close()
 
 # Returns a list of entries base on date. Defaults to last entry. -1 is all entries.
@@ -126,11 +127,11 @@ if __name__ == '__main__':
     date_in = datetime(2020, 9, 10, 23, 55, 59).timestamp()
     date_out = datetime(2020, 8, 13, 23, 55, 59).timestamp()
 
-    add_roll("Russell6", "Russ6", "1d6+34-4", "(3)+34-4", 33, 45, None)
+    #add_roll("Russell6", "Russ6", "1d6+34-4", "(3)+34-4", 33, 45, None)
 
     #get_entry(date_in_epoch=date_in, date_out_epoch=date_out, number_of_entries=-1)
-    for record in get_entry(number_of_entries=10):
-        print (record)
+    #for record in get_entry(number_of_entries=10):
+    #    print (record)
 
     #create_licorice()
     #licorice = get_random_licorice()

--- a/diceroller.py
+++ b/diceroller.py
@@ -4,7 +4,7 @@ UNARY_OPS = (ast.UAdd, ast.USub)
 BINARY_OPS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod)
 
 class DiceResult:
-  def __init__(self, argument=None, equation=None, sumtotal=None, stat=None, comment=None, timestamp=None):
+  def __init__(self, argument=None, equation=None, sumtotal=None, stat=None, comment=None, timestamp=None, user=None, nick=None):
     '''this will eventually be an additional class that holds the results of rolls since there's a possible scenario for multi-rolling'''
     self.argument = argument
     self.equation = equation
@@ -12,6 +12,8 @@ class DiceResult:
     self.stat = stat
     self.comment = comment
     self.timestamp = timestamp
+    self.user = user
+    self.nick = nick
 
   def get_timestamp(self):
     return self.timestamp

--- a/diceroller.py
+++ b/diceroller.py
@@ -1,16 +1,27 @@
-import re, random, ast
+import re, random, ast, time, datetime
 
 UNARY_OPS = (ast.UAdd, ast.USub)
 BINARY_OPS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod)
 
 class DiceResult:
-  def __init__(self, argument=None, equation=None, sumtotal=None, stat=None, comment=None):
+  def __init__(self, argument=None, equation=None, sumtotal=None, stat=None, comment=None, timestamp=None):
     '''this will eventually be an additional class that holds the results of rolls since there's a possible scenario for multi-rolling'''
     self.argument = argument
     self.equation = equation
     self.sumtotal = sumtotal
     self.stat = stat
     self.comment = comment
+    self.timestamp = timestamp
+
+  def get_timestamp(self):
+    return self.timestamp
+  
+  def get_timestamp_datetime(self):
+    return time.localtime(self.timestamp)
+  
+  def get_timestamp_pretty(self):
+    #return time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(1347517370))
+    return datetime.datetime.fromtimestamp(self.timestamp).strftime('%c')
 
   def get_argument(self):
     return self.argument


### PR DESCRIPTION
This ended up being more than just the guild and channel added to the database.  The database now stores channel and guild for more fine-tuned data later.  This way, if the Keeper is rolling privately or the bot exists in more than one place, it'll keep track of where the rolls are coming from.  This will link to charts and stuff later.

Also updated the roll dice class so it includes discord account and name.  These need to get called up later and just needed to be more cleanly integrated.

I also started the ball rolling on some voice interaction.  I allowed the bot to enter the channel and gave it simple commands to speak.  This will eventually be a more thought out tool so that roll results are announced in the channel.  